### PR TITLE
fix: add SpotOn (soc) transcoding templates for DSP processing

### DIFF
--- a/SqueezeDSP/TemplateConfig.pm
+++ b/SqueezeDSP/TemplateConfig.pm
@@ -10,6 +10,7 @@ sub get_config_revision
 	return $configrevision;
 }
 
+# 0.2.02 added soc (SpotOn) — Spotify HTTP streaming, convolver reads PCM from stdin
 # 0.2.01 Amended all settings to use new SqueezeDSP adapter Eliminated wav16 replace with MP3
 # 0.1.11 corrected ogf line which had duplicate convolver app.
 # 0.1.10 added hls flc and wav
@@ -106,6 +107,10 @@ ogf mp3 * $CLIENTID$
 ops mp3 * $CLIENTID$
 	# IFB:{BITRATE=--abr %B}D:{RESAMPLE=--maxSampleRate=%d}
 	[sox] -q -t opus $FILE$ -t wav - |  [$CONVAPP$]  --trackURL=$URL$ $RESAMPLE$ --Clientid="$CLIENTID$"  --bitsout=24 --formatout=MP3
+
+soc mp3 * $CLIENTID$
+	# I
+	[$CONVAPP$] --bitsin=$SAMPLESIZE$ --samplerate=$SAMPLERATE$ --be=false --channels=$CHANNELS$ --formatin=PCM --trackURL=$URL$ --Clientid="$CLIENTID$" --bitsout=24 --formatout=MP3
 
 spt mp3 * $CLIENTID$
 	# RT:{START=--start-position %s}
@@ -207,6 +212,10 @@ ogf flc * $CLIENTID$
 ops flc * $CLIENTID$
 	# IFB:{BITRATE=--abr %B}D:{RESAMPLE=--maxSampleRate=%d}
 	[sox] -q -t opus $FILE$ -t wav - |  [$CONVAPP$]  --trackURL=$URL$ $RESAMPLE$ --Clientid="$CLIENTID$"  --bitsout=24 --formatout=FLC
+
+soc flc * $CLIENTID$
+	# I
+	[$CONVAPP$] --bitsin=$SAMPLESIZE$ --samplerate=$SAMPLERATE$ --be=false --channels=$CHANNELS$ --formatin=PCM --trackURL=$URL$ --Clientid="$CLIENTID$" --bitsout=24 --formatout=FLC
 
 spt flc * $CLIENTID$
 	# RT:{START=--start-position %s}

--- a/SqueezeDSP/TemplateConfig.pm
+++ b/SqueezeDSP/TemplateConfig.pm
@@ -10,7 +10,7 @@ sub get_config_revision
 	return $configrevision;
 }
 
-# 0.2.02 added soc (SpotOn) — Spotify HTTP streaming, convolver reads PCM from stdin
+# 0.2.02 added soc (SpotOn Coded/PCM) and son (SpotOn Native/OGG passthrough)
 # 0.2.01 Amended all settings to use new SqueezeDSP adapter Eliminated wav16 replace with MP3
 # 0.1.11 corrected ogf line which had duplicate convolver app.
 # 0.1.10 added hls flc and wav
@@ -111,6 +111,10 @@ ops mp3 * $CLIENTID$
 soc mp3 * $CLIENTID$
 	# I
 	[$CONVAPP$] --bitsin=$SAMPLESIZE$ --samplerate=$SAMPLERATE$ --be=false --channels=$CHANNELS$ --formatin=PCM --trackURL=$URL$ --Clientid="$CLIENTID$" --bitsout=24 --formatout=MP3
+
+son mp3 * $CLIENTID$
+	# I
+	[sox] -q -t ogg - -t wav - | [$CONVAPP$] --bitsin=$SAMPLESIZE$ --samplerate=$SAMPLERATE$ --be=false --channels=$CHANNELS$ --formatin=PCM --trackURL=$URL$ --Clientid="$CLIENTID$" --bitsout=24 --formatout=MP3
 
 spt mp3 * $CLIENTID$
 	# RT:{START=--start-position %s}
@@ -216,6 +220,10 @@ ops flc * $CLIENTID$
 soc flc * $CLIENTID$
 	# I
 	[$CONVAPP$] --bitsin=$SAMPLESIZE$ --samplerate=$SAMPLERATE$ --be=false --channels=$CHANNELS$ --formatin=PCM --trackURL=$URL$ --Clientid="$CLIENTID$" --bitsout=24 --formatout=FLC
+
+son flc * $CLIENTID$
+	# I
+	[sox] -q -t ogg - -t wav - | [$CONVAPP$] --bitsin=$SAMPLESIZE$ --samplerate=$SAMPLERATE$ --be=false --channels=$CHANNELS$ --formatin=PCM --trackURL=$URL$ --Clientid="$CLIENTID$" --bitsout=24 --formatout=FLC
 
 spt flc * $CLIENTID$
 	# RT:{START=--start-position %s}


### PR DESCRIPTION
## Summary

SqueezeDSP's `removeNativeConversion()` deletes SpotOn's native passthrough transcoding profile (`soc pcm * *` with command `-`), breaking SpotOn playback when SqueezeDSP is enabled.

## Approach

Adds `soc mp3` and `soc flc` templates to `TemplateConfig.pm`, analogous to the existing `spt` (Spotty) templates. This follows the same implicit-protection pattern: profiles containing the convolver binary are preserved by `removeNativeConversion()`.

**Key difference from Spotty:** SpotOn delivers decoded PCM via HTTP streaming (unified daemon architecture), so no decoder binary is needed in the pipeline. The convolver reads PCM directly from stdin:

```
soc mp3 * $CLIENTID$
    # I
    [$CONVAPP$] --bitsin=$SAMPLESIZE$ --samplerate=$SAMPLERATE$ --be=false --channels=$CHANNELS$ --formatin=PCM --trackURL=$URL$ --Clientid="$CLIENTID$" --bitsout=24 --formatout=MP3
```

Compare with the Spotty template which needs `[spotty]` as decoder first:
```
spt mp3 * $CLIENTID$
    # RT:{START=--start-position %s}
    [spotty] ... --single-track $URL$ ... | [$CONVAPP$] --bitsin=... --formatout=MP3
```

## Benefits

- SpotOn playback works when SqueezeDSP is enabled
- SpotOn audio gets DSP processing through the convolver (not just unbroken passthrough)
- No changes to `Configuration.pm` / `removeNativeConversion()` needed

## Note on config revision

The changelog comment references `0.2.02` but `get_config_revision()` still returns `0.2.01`. Bumping it would trigger config regeneration for existing users (so they pick up the new `soc` templates automatically). I've left that decision to you.

## References

- Issue: https://github.com/Foxenfurter/SqueezeDSP/issues/18
- User report: https://github.com/stiefenm/spoton/issues/42
- SpotOn plugin: https://github.com/stiefenm/spoton